### PR TITLE
Backport network reset fixes

### DIFF
--- a/SOURCES/xsconsole-11.0.8-do-not-truncate-ipv6-in-pool-config-on-reset.patch
+++ b/SOURCES/xsconsole-11.0.8-do-not-truncate-ipv6-in-pool-config-on-reset.patch
@@ -1,0 +1,31 @@
+From c0ad5369a51bd45428d4908d647caf7a32542bf3 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 9 Apr 2025 15:49:47 +0100
+Subject: [PATCH] NetworkReset: don't truncate the IPv6 address of the
+ coordinator host
+
+Otherwise, for a pool.conf like `slave:2a01:240:ab08:5:13::201`, the
+dialog would just display `2a01`
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ plugins-base/XSFeatureNetworkReset.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/plugins-base/XSFeatureNetworkReset.py b/plugins-base/XSFeatureNetworkReset.py
+index b20a08c..c69009b 100644
+--- a/plugins-base/XSFeatureNetworkReset.py
++++ b/plugins-base/XSFeatureNetworkReset.py
+@@ -63,7 +63,8 @@ class NetworkResetDialogue(Dialogue):
+ 		f = open(pool_conf, 'r')
+ 		try:
+ 			l = f.readline()
+-			ls = l.split(':')
++			# split "slave:ipaddress" such that IPv6 address is preserved
++			ls = l.split(':', maxsplit=1)
+ 			if ls[0] == 'slave':
+ 				self.master_ip = ls[1]
+ 		finally:
+-- 
+2.50.1
+

--- a/SOURCES/xsconsole-11.0.8-sync-network-reset-trigger-file.patch
+++ b/SOURCES/xsconsole-11.0.8-sync-network-reset-trigger-file.patch
@@ -1,0 +1,31 @@
+From 7b7a3bde0089ddfb1cb763182fd8fd3e9b45fa31 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Fri, 11 Apr 2025 15:36:31 +0100
+Subject: [PATCH] NetworkReset: Sync up the network-reset file path with xapi
+
+It was changed in xapi back in Aug 2024
+(92561391840d9de31ad70249166ee43c2de9cb8d, see
+https://github.com/xapi-project/xen-api/pull/5933), without syncing up
+xsconsole.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ plugins-base/XSFeatureNetworkReset.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins-base/XSFeatureNetworkReset.py b/plugins-base/XSFeatureNetworkReset.py
+index c69009b..2ab99e8 100644
+--- a/plugins-base/XSFeatureNetworkReset.py
++++ b/plugins-base/XSFeatureNetworkReset.py
+@@ -22,7 +22,7 @@ pool_conf = '%s/pool.conf' % (Config.Inst().XCPConfigDir())
+ interface_reconfigure = '%s/interface-reconfigure' % (Config.Inst().LibexecPath())
+ inventory_file = '/etc/xensource-inventory'
+ management_conf = '/etc/firstboot.d/data/management.conf'
+-network_reset = '/tmp/network-reset'
++network_reset = '/var/tmp/network-reset'
+ 
+ def read_dict_file(fname):
+ 	f = open(fname, 'r')
+-- 
+2.50.1
+

--- a/SPECS/xsconsole.spec
+++ b/SPECS/xsconsole.spec
@@ -5,7 +5,7 @@
 Summary: XCP-ng Host Configuration Console
 Name: xsconsole
 Version: 11.0.8
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPL2
 Group: Administration/System
 Source0: xsconsole-11.0.8.tar.gz
@@ -35,6 +35,9 @@ Patch1001: xsconsole-10.1.13-define-xcp-ng-colors.XCP-ng.patch
 # PR pending merge
 Patch1002: xsconsole-11.0.2-support-ipv6.XCP-ng.patch
 Patch1003: xsconsole-11.0.6-Ipv6-pool-join.XCP-ng.patch
+# Sync network reset trigger file path with XAPI - To be removed on next rebase
+Patch1004: xsconsole-11.0.8-sync-network-reset-trigger-file.patch
+Patch1005: xsconsole-11.0.8-do-not-truncate-ipv6-in-pool-config-on-reset.patch
 
 %description
 Console tool for configuring a XCP-ng installation.
@@ -71,6 +74,10 @@ Console tool for configuring a XCP-ng installation.
 %{_unitdir}/xsconsole.service
 
 %changelog
+* Wed Aug 20 2025 David Morel <david.morel@vates.tech> - 11.0.8-1.2
+- Backport fix to sync network reset trigger file with current XAPI
+- Backport fix for IPv6 truncated in pool.conf on network reset
+
 * Wed Mar 05 2025 Samuel Verschelde <stormi-xcp@ylix.fr> - 11.0.8-1.1
 - Sync with 11.0.8-1
 - *** Upstream changelog ***


### PR DESCRIPTION
In XAPI 24.22.0-1, that we included in our rebase to 24.39.1-1.1, the trigger file path was changed from /tmp to /var/tmp, xsconsole was not updated to sync with that in our package, nor is the one from XenServer at this time.

Backport the sibbling fix for IPv6 truncaction in pool.conf when using coordinator's IPv6.