### PR TITLE
Backport #85 and #86 upstream PRs

### DIFF
--- a/SOURCES/xsconsole-network-reset-without-management-interface-rename.patch
+++ b/SOURCES/xsconsole-network-reset-without-management-interface-rename.patch
@@ -1,0 +1,106 @@
+From 098b204f7be3a29e00facdef0429a19660e21031 Mon Sep 17 00:00:00 2001
+From: Stefanos Gerangelos <stefanos.gerangelos@vates.tech>
+Date: Wed, 14 Jan 2026 18:13:07 +0200
+Subject: [PATCH] XSFeatureNetworkReset: allow the user to perform an emergency
+ network reset without renaming the management interface
+
+There are some use cases according to which the user would like to perform an
+emergency network reset by keeping the management interface's name intact. This
+commit allows the user to proceed to an emergency network reset by requesting
+the aforementioned behavior.
+
+Signed-off-by: Stefanos Gerangelos <stefanos.gerangelos@vates.tech>
+---
+ plugins-base/XSFeatureNetworkReset.py | 37 ++++++++++++++++++++++++---
+ 1 file changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/plugins-base/XSFeatureNetworkReset.py b/plugins-base/XSFeatureNetworkReset.py
+index 62442d0..2d33657 100644
+--- a/plugins-base/XSFeatureNetworkReset.py
++++ b/plugins-base/XSFeatureNetworkReset.py
+@@ -82,6 +82,12 @@ class NetworkResetDialogue(Dialogue):
+ 		except:
+ 			self.vlan = ''
+ 
++		self.renameMgmt = True
++		self.renameMenu = Menu(self, None, Lang("Choose to rename/keep the Management Interface name"), [
++			ChoiceDef(Lang("Rename"), lambda: self.HandleRenameChoice('RENAME') ),
++			ChoiceDef(Lang("Keep name"), lambda: self.HandleRenameChoice('KEEP') )
++			])
++
+ 		self.modeMenu = Menu(self, None, Lang("Select IP Address Configuration Mode"), [
+ 			ChoiceDef(Lang("DHCP"), lambda: self.HandleModeChoice('DHCP') ),
+ 			ChoiceDef(Lang("Static"), lambda: self.HandleModeChoice('STATIC') )
+@@ -126,6 +132,14 @@ class NetworkResetDialogue(Dialogue):
+ 		if pane.InputIndex() is None:
+ 			pane.InputIndexSet(0) # Activate first field for input
+ 
++	def UpdateFieldsRENAME(self):
++		pane = self.Pane()
++		pane.ResetFields()
++
++		pane.AddTitleField(Lang("Choose to rename/keep the Management Interface name"))
++		pane.AddMenuField(self.renameMenu)
++		pane.AddKeyHelpField( { Lang("<Enter>") : Lang("OK"), Lang("<Esc>") : Lang("Cancel") } )
++
+ 	def UpdateFieldsMODE(self):
+ 		pane = self.Pane()
+ 		pane.ResetFields()
+@@ -168,6 +182,10 @@ class NetworkResetDialogue(Dialogue):
+ 
+ 		pane.AddWrappedTextField(Lang("The Primary Management Interface will be reconfigured with the following settings:"))
+ 		pane.AddStatusField(Lang("NIC",  16),  self.device)
++		if self.renameMgmt:
++			pane.AddStatusField(Lang("Rename NIC:", 16),  "Yes")
++		else:
++			pane.AddStatusField(Lang("Rename NIC:", 16),  "No")
+ 		if self.vlan != '':
+ 			pane.AddStatusField(Lang("VLAN",  16),  self.vlan)
+ 		pane.AddStatusField(Lang("IP Mode",  16),  self.mode)
+@@ -214,7 +232,7 @@ class NetworkResetDialogue(Dialogue):
+ 					pane.InputIndexSet(None)
+ 					Layout.Inst().PushDialogue(InfoDialogue(Lang('VLAN tag must be between 0 and 4094')))
+ 				else:
+-					self.ChangeState('MODE')
++					self.ChangeState('RENAME')
+ 			else:
+ 				pane.ActivateNextInput()
+ 		elif inKey == 'KEY_TAB':
+@@ -227,6 +245,9 @@ class NetworkResetDialogue(Dialogue):
+ 			handled = False
+ 		return handled
+ 
++	def HandleKeyRENAME(self, inKey):
++		return self.renameMenu.HandleKey(inKey)
++
+ 	def HandleKeyMODE(self, inKey):
+ 		return self.modeMenu.HandleKey(inKey)
+ 
+@@ -315,6 +336,12 @@ class NetworkResetDialogue(Dialogue):
+ 
+ 		return handled
+ 
++	def HandleRenameChoice(self,  inChoice):
++		if inChoice == 'KEEP':
++			self.renameMgmt = False
++
++		self.ChangeState('MODE')
++
+ 	def HandleModeChoice(self,  inChoice):
+ 		if inChoice == 'DHCP':
+ 			self.mode = 'dhcp'
+@@ -410,8 +437,12 @@ class NetworkResetDialogue(Dialogue):
+ 
+ 		# Reset the domain 0 network interface naming configuration
+ 		# back to a fresh-install state for the currently-installed
+-		# hardware.
+-		os.system("/etc/sysconfig/network-scripts/interface-rename.py --reset-to-install")
++		# hardware (unless prevented by the user).
++		if self.renameMgmt:
++			XSLog('Will rename the Management Interface')
++			os.system("/etc/sysconfig/network-scripts/interface-rename.py --reset-to-install")
++		else:
++			XSLog('Will NOT rename the Management Interface')
+ 
+ class XSFeatureNetworkReset:
+ 	@classmethod

--- a/SOURCES/xsconsole-reset-old-management-interface-when-switching-to-new.patch
+++ b/SOURCES/xsconsole-reset-old-management-interface-when-switching-to-new.patch
@@ -1,0 +1,77 @@
+From 4dd53f6e64ee4a62220af2d6f392ceb695c2c766 Mon Sep 17 00:00:00 2001
+From: Stefanos Gerangelos <stefanos.gerangelos@vates.tech>
+Date: Mon, 22 Jun 2026 14:40:11 +0200
+Subject: [PATCH] XSFeatureInterface: Reset old management interface
+ configuration when switching to a new one
+
+Fix the following issue from upstream:
+https://github.com/xapi-project/xsconsole/issues/8
+
+Essentially, reset the old management interface configuration when
+switching to a new one, in order to avoid network conflicts
+
+Signed-off-by: Stefanos Gerangelos <stefanos.gerangelos@vates.tech>
+---
+ plugins-base/XSFeatureInterface.py | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/plugins-base/XSFeatureInterface.py b/plugins-base/XSFeatureInterface.py
+index e5cf547..c812cc3 100644
+--- a/plugins-base/XSFeatureInterface.py
++++ b/plugins-base/XSFeatureInterface.py
+@@ -28,6 +28,7 @@ class InterfaceDialogue(Dialogue):
+         self.nic=None
+         self.converting = False
+         currentPIF = None
++        self.oldPIF = None
+         choiceArray = []
+         for i in range(len(data.host.PIFs([]))):
+             pif = data.host.PIFs([])[i]
+@@ -45,6 +46,7 @@ class InterfaceDialogue(Dialogue):
+ 
+             choiceDefs.append(ChoiceDef(choiceName, lambda: self.HandleNICChoice(self.nicMenu.ChoiceIndex())))
+ 
++        self.oldPIF = currentPIF
+         if len(choiceDefs) == 0:
+             XSLog('Configure Management Interface found no PIFs to present')
+             choiceDefs.append(ChoiceDef(Lang("<No interfaces present>"), None))
+@@ -84,6 +86,7 @@ class InterfaceDialogue(Dialogue):
+         self.netmask = '0.0.0.0'
+         self.gateway = '0.0.0.0'
+         self.hostname = data.host.hostname('')
++        self.oldIP = self.IP
+ 
+         if currentPIF is not None:
+             ipv6 = currentPIF['primary_address_type'].lower() == 'ipv6'
+@@ -93,6 +96,7 @@ class InterfaceDialogue(Dialogue):
+             if self.mode.lower().startswith('static'):
+                 if 'IP' in currentPIF:
+                     self.IP = currentPIF['IPv6'][0].split('/')[0] if ipv6 else currentPIF['IP']
++                    self.oldIP = self.IP
+                 if 'netmask' in currentPIF:
+                     self.netmask = currentPIF['IPv6'][0].split('/')[1] if ipv6 else currentPIF['netmask']
+                 if 'gateway' in currentPIF:
+@@ -110,6 +114,9 @@ class InterfaceDialogue(Dialogue):
+             self.nicMenu.AddChoice(name = Lang('Renew DHCP Lease On Current Interface'),
+                 onAction = lambda: self.HandleRenewChoice()
+                 )
++            if currentPIF is not None and 'IP' in currentPIF:
++                self.IP = currentPIF['IPv6'][0].split('/')[0] if ipv6 else currentPIF['IP']
++                self.oldIP = self.IP
+ 
+         self.ChangeState('INITIAL')
+ 
+@@ -458,7 +465,13 @@ class InterfaceDialogue(Dialogue):
+                 data.HostnameSet('localhost')
+             else:
+                 data.HostnameSet(self.hostname)
++
++            # Reset old PIF in order to prevent network conflicts
++            if self.mode.lower().startswith('static') and self.oldPIF != pif and self.IP == self.oldIP:
++                data.ReconfigureManagement(self.oldPIF, 'static', '0.0.0.0',  '0.0.0.0', '0.0.0.0', '')
++
+             data.ReconfigureManagement(pif, self.mode, self.IP,  self.netmask, self.gateway, dns)
++
+         data.Update()
+         self.hostname = data.host.hostname('') # Hostname may have changed.  Must be after data.Update()
+ 

--- a/SPECS/xsconsole.spec
+++ b/SPECS/xsconsole.spec
@@ -5,7 +5,7 @@
 Summary: XCP-ng Host Configuration Console
 Name: xsconsole
 Version: 11.0.9.1
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPL2
 Group: Administration/System
 Source0: xsconsole-11.0.9.1.tar.gz
@@ -35,6 +35,8 @@ Patch1001: xsconsole-10.1.13-define-xcp-ng-colors.XCP-ng.patch
 # PR pending merge
 Patch1002: xsconsole-11.0.2-support-ipv6.XCP-ng.patch
 Patch1003: xsconsole-11.0.6-Ipv6-pool-join.XCP-ng.patch
+Patch1004: xsconsole-network-reset-without-management-interface-rename.patch
+Patch1005: xsconsole-reset-old-management-interface-when-switching-to-new.patch
 
 %description
 Console tool for configuring a XCP-ng installation.
@@ -71,6 +73,9 @@ Console tool for configuring a XCP-ng installation.
 %{_unitdir}/xsconsole.service
 
 %changelog
+* Mon Jun 22 2026 Stefanos Gerangelos <stefanos.gerangelos@vates.tech> - 11.0.9.1-2
+- Backport the user option to allow the network reset without renaming the management interface (upstream PR #85)
+- Backport the reset of old management interface configuration when switching to a new one (upstream PR #86)
 * Tue Sep 02 2025 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 11.0.9.1-1.1
 - Sync with 11.0.9.1-1
 - Drop xsconsole-11.0.8-sync-network-reset-trigger-file.patch

--- a/SPECS/xsconsole.spec
+++ b/SPECS/xsconsole.spec
@@ -73,9 +73,10 @@ Console tool for configuring a XCP-ng installation.
 %{_unitdir}/xsconsole.service
 
 %changelog
-* Mon Jun 22 2026 Stefanos Gerangelos <stefanos.gerangelos@vates.tech> - 11.0.9.1-2
+* Mon Jun 22 2026 Stefanos Gerangelos <stefanos.gerangelos@vates.tech> - 11.0.9.1-1.2
 - Backport the user option to allow the network reset without renaming the management interface (upstream PR #85)
 - Backport the reset of old management interface configuration when switching to a new one (upstream PR #86)
+ 
 * Tue Sep 02 2025 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 11.0.9.1-1.1
 - Sync with 11.0.9.1-1
 - Drop xsconsole-11.0.8-sync-network-reset-trigger-file.patch


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3456

#### Related changes (optional)

N/A

#### Context & Motivation

- XSFeatureNetworkReset: Allow the user to perform an emergency network reset without renaming the management interface

There are some use cases according to which the user would like to perform an emergency network reset by keeping the management interface's name intact. This PR allows the user to proceed to an emergency network reset by requesting the aforementioned behavior.

- XSFeatureInterface: Reset old management interface configuration when switching to a new one

Fix the following issue from upstream:
https://github.com/xapi-project/xsconsole/issues/8

Essentially, reset the old management interface configuration when switching to a new one, in order to avoid network conflicts

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

Samuel: 8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

- Add the option not to rename the management interface when performing an emergency network reset
- Reset the old management interface IP configuration when switching to a new interface with the same IP address 

~~ANSWER~~

#### Attention points

In case the target conditions are met, the second patch will result in the old management interface to reset its IP address ('0.0.0.0')

#### Documentation update needed

- [ ] Yes
- [ ] No
- [x] I'm not sure, help me

~~EXPLANATIONS~~

The first patch introduces a new dialogue window that the user has the option to a) rename the management interface or b) keep it intact.

---

### Testing and regression avoidance

#### What tests have you performed?

No automated tests cover xsconsole
Manual testing of the console (before build) with network interface modifications.
~~koj build: https://koji.xcp-ng.org/taskinfo?taskID=107149~~
koji build: https://koji.xcp-ng.org/taskinfo?taskID=108041

#### What manual tests should be performed after the build, and by whom?

- Perform a network reset with a) renaming the interface and b) keeping the name intact
- Switch the management interface to a new NIC  with the same IP address as the old one (the latest operation works for static assignment, but the previous one could be both static or DHCP)

#### What's covered by the xcp-ng-tests test suite?

None

#### What tests have been or will be added to CI for this change? If none, explain why.

There is a task (XCPNG-3476) created for this in order to create the relevant testing

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No
